### PR TITLE
big refactor

### DIFF
--- a/examples/example.jl
+++ b/examples/example.jl
@@ -224,12 +224,9 @@ function start()
             SI.TEXT_BOX,
             ui_context,
             SI.WidgetID(@__FILE__, @__LINE__, 1),
-            SI.UP1_RIGHT2,
-            widget_gap,
-            font_height,
-            20 * font_width,
-            text_box_value,
-            font,
+            text_box_value;
+            alignment = SI.UP1_RIGHT2,
+            widget_width = 20 * font_width,
         )
 
         layout.reference_bounding_box = temp_bounding_box

--- a/examples/example.jl
+++ b/examples/example.jl
@@ -164,24 +164,16 @@ function start()
             SI.TEXT,
             ui_context,
             SI.WidgetID(@__FILE__, @__LINE__, 1),
-            SI.UP1_LEFT1,
-            widget_gap,
-            font_height,
-            SI.get_num_printable_characters(text) * font_width,
-            text,
-            font,
+            text;
+            alignment = SI.UP1_LEFT1,
         )
 
         SI.do_widget!(
             SI.TEXT,
             ui_context,
             SI.WidgetID(@__FILE__, @__LINE__, 1),
-            SI.DOWN2_LEFT1,
-            widget_gap,
-            font_height,
-            12 * font_width,
-            "Button",
-            font,
+            "Button";
+            widget_width = 12 * font_width,
         )
         temp_bounding_box = layout.reference_bounding_box
 
@@ -189,12 +181,9 @@ function start()
             SI.BUTTON,
             ui_context,
             SI.WidgetID(@__FILE__, @__LINE__, 1),
-            SI.UP1_RIGHT2,
-            widget_gap,
-            font_height,
-            20 * font_width,
-            "$(button_num_clicks)",
-            font,
+            "$(button_num_clicks)";
+            alignment = SI.UP1_RIGHT2,
+            widget_width = 20 * font_width,
         )
         if button_value
             button_num_clicks += 1
@@ -205,12 +194,8 @@ function start()
             SI.TEXT,
             ui_context,
             SI.WidgetID(@__FILE__, @__LINE__, 1),
-            SI.DOWN2_LEFT1,
-            widget_gap,
-            font_height,
-            12 * font_width,
-            "Slider",
-            font,
+            "Slider";
+            widget_width = 12 * font_width,
         )
         temp_bounding_box = layout.reference_bounding_box
 
@@ -230,12 +215,8 @@ function start()
             SI.TEXT,
             ui_context,
             SI.WidgetID(@__FILE__, @__LINE__, 1),
-            SI.DOWN2_LEFT1,
-            widget_gap,
-            font_height,
-            12 * font_width,
-            "TextBox",
-            font,
+            "TextBox";
+            widget_width = 12 * font_width,
         )
         temp_bounding_box = layout.reference_bounding_box
 
@@ -256,12 +237,8 @@ function start()
             SI.TEXT,
             ui_context,
             SI.WidgetID(@__FILE__, @__LINE__, 1),
-            SI.DOWN2_LEFT1,
-            widget_gap,
-            font_height,
-            12 * font_width,
-            "Image",
-            font,
+            "Image";
+            widget_width = 12 * font_width,
         )
         temp_bounding_box = layout.reference_bounding_box
 
@@ -296,12 +273,8 @@ function start()
             SI.TEXT,
             ui_context,
             SI.WidgetID(@__FILE__, @__LINE__, 1),
-            SI.DOWN2_LEFT1,
-            widget_gap,
-            font_height,
-            12 * font_width,
-            "RadioButton",
-            font,
+            "RadioButton";
+            widget_width = 12 * font_width,
         )
         temp_bounding_box = layout.reference_bounding_box
 
@@ -333,12 +306,8 @@ function start()
             SI.TEXT,
             ui_context,
             SI.WidgetID(@__FILE__, @__LINE__, 1),
-            SI.DOWN2_LEFT1,
-            widget_gap,
-            font_height,
-            12 * font_width,
-            "DropDown",
-            font,
+            "DropDown";
+            widget_width = 12 * font_width,
         )
         temp_bounding_box = layout.reference_bounding_box
 
@@ -386,12 +355,8 @@ function start()
             SI.TEXT,
             ui_context,
             SI.WidgetID(@__FILE__, @__LINE__, 1),
-            SI.DOWN2_LEFT1,
-            widget_gap,
-            font_height,
-            12 * font_width,
-            "CheckBox",
-            font,
+            "CheckBox";
+            widget_width = 12 * font_width,
         )
         temp_bounding_box = layout.reference_bounding_box
         push!(debug_text_list, "previous frame number: $(i)")
@@ -428,12 +393,7 @@ function start()
                     SI.TEXT,
                     ui_context,
                     SI.WidgetID(@__FILE__, @__LINE__, j),
-                    SI.DOWN2_LEFT1,
-                    widget_gap,
-                    font_height,
-                    SI.get_num_printable_characters(text) * font_width,
-                    text,
-                    font,
+                    text;
                 )
             end
         end

--- a/examples/example.jl
+++ b/examples/example.jl
@@ -203,11 +203,10 @@ function start()
             SI.SLIDER,
             ui_context,
             SI.WidgetID(@__FILE__, @__LINE__, 1),
-            slider_value,
-            SI.UP1_RIGHT2,
-            widget_gap,
-            slider_height,
-            slider_width,
+            slider_value;
+            alignment = SI.UP1_RIGHT2,
+            widget_height = slider_height,
+            widget_width = slider_width,
         )
 
         layout.reference_bounding_box = temp_bounding_box
@@ -255,11 +254,8 @@ function start()
             SI.SLIDER,
             ui_context,
             SI.WidgetID(@__FILE__, @__LINE__, 1),
-            image_widget_horizontal_slider_value,
-            SI.DOWN2_LEFT1,
-            widget_gap,
-            font_height,
-            20 * font_width,
+            image_widget_horizontal_slider_value;
+            widget_width = 20 * font_width,
         )
         image_widget_j_scroll = SI.get_scroll_value(image_widget_horizontal_slider_value[2], image_widget_horizontal_slider_value[4], image_widget_horizontal_slider_value[8], image_widget_width, SD.get_width(image_widget_drawable))
         image_widget_drawable = SD.Image(SD.move(SD.Point(1, 1), 0, -image_widget_j_scroll), image_widget_drawable.image)

--- a/examples/example.jl
+++ b/examples/example.jl
@@ -239,15 +239,15 @@ function start()
         )
         temp_bounding_box = layout.reference_bounding_box
 
-        text_box_value = SI.do_widget!(
+        SI.do_widget!(
             SI.TEXT_BOX,
             ui_context,
             SI.WidgetID(@__FILE__, @__LINE__, 1),
-            text_box_value,
             SI.UP1_RIGHT2,
             widget_gap,
             font_height,
             20 * font_width,
+            text_box_value,
             font,
         )
 

--- a/examples/example.jl
+++ b/examples/example.jl
@@ -289,12 +289,9 @@ function start()
                 ui_context,
                 SI.WidgetID(@__FILE__, @__LINE__, j),
                 radio_button_value == j,
-                SI.UP1_RIGHT2,
-                widget_gap,
-                font_height,
-                (max_num_chars + 2) * font_width,
-                "$(item)",
-                font,
+                "$(item)";
+                alignment = SI.UP1_RIGHT2,
+                widget_width = (max_num_chars + 2) * font_width,
             )
                 radio_button_value = j
             end
@@ -321,12 +318,9 @@ function start()
             ui_context,
             SI.WidgetID(@__FILE__, @__LINE__, 1),
             drop_down_value,
-            SI.UP1_RIGHT2,
-            widget_gap,
-            font_height,
-            (max_num_chars + 2) * font_width,
-            drop_down_item_list[drop_down_selected_item],
-            font,
+            drop_down_item_list[drop_down_selected_item];
+            alignment = SI.UP1_RIGHT2,
+            widget_width = (max_num_chars + 2) * font_width,
         )
         temp_bounding_box = SI.get_enclosing_bounding_box(temp_bounding_box, layout.reference_bounding_box)
 
@@ -337,12 +331,9 @@ function start()
                     ui_context,
                     SI.WidgetID(@__FILE__, @__LINE__, j),
                     drop_down_selected_item == j,
-                    SI.DOWN2_LEFT1,
-                    0,
-                    font_height,
-                    (max_num_chars + 2) * font_width,
-                    "$(item)",
-                    font,
+                    "$(item)";
+                    padding = 0,
+                    widget_width = (max_num_chars + 2) * font_width,
                 )
                     drop_down_selected_item = j
                 end
@@ -378,12 +369,8 @@ function start()
             ui_context,
             SI.WidgetID(@__FILE__, @__LINE__, 1),
             check_box_value,
-            SI.UP1_RIGHT2,
-            widget_gap,
-            font_height,
-            (SI.get_num_printable_characters(text) + 2) * font_width,
-            text,
-            font,
+            text;
+            alignment = SI.UP1_RIGHT2,
         )
 
         if check_box_value

--- a/examples/example.jl
+++ b/examples/example.jl
@@ -242,11 +242,10 @@ function start()
             SI.IMAGE,
             ui_context,
             SI.WidgetID(@__FILE__, @__LINE__, 1),
-            SI.UP1_RIGHT2,
-            widget_gap,
-            image_widget_height,
-            image_widget_width,
-            image_widget_drawable,
+            image_widget_drawable;
+            alignment = SI.UP1_RIGHT2,
+            widget_height = image_widget_height,
+            widget_width = image_widget_width,
         )
         temp_bounding_box = SI.get_enclosing_bounding_box(temp_bounding_box, layout.reference_bounding_box)
 

--- a/src/drawing.jl
+++ b/src/drawing.jl
@@ -86,7 +86,7 @@ function draw_widget_unclipped!(widget_type::Button, image, bounding_box, user_i
     return nothing
 end
 
-function draw_widget_unclipped!(widget_type::TextBox, image, bounding_box, user_interaction_state, this_widget, text, alignment, padding, font, background_contextual_color, border_contextual_color, text_contextual_color)
+function draw_widget_unclipped!(widget_type::TextBox, image, bounding_box, user_interaction_state, this_widget, alignment, padding, text, font, background_contextual_color, border_contextual_color, text_contextual_color)
     if this_widget == user_interaction_state.active_widget
         background_color = background_contextual_color.active_color
         border_color = border_contextual_color.active_color

--- a/src/widget_core.jl
+++ b/src/widget_core.jl
@@ -124,23 +124,9 @@ do_widget!!(widget_type::Union{Button, Text, Image}, args...; kwargs...) = do_wi
 ##### TextBox
 #####
 
-function get_widget_value!(::TextBox, hot_widget, active_widget, this_widget, widget_value, characters)
-    if (hot_widget == this_widget) && (active_widget == this_widget)
-        for character in characters
-            if isprint(character)
-                push!(widget_value, character)
-            elseif character == '\b'
-                if get_num_printable_characters(widget_value) > 0
-                    pop!(widget_value)
-                end
-            end
-        end
-    end
+get_widget_value(::TextBox, hot_widget, active_widget, this_widget) = (hot_widget == this_widget) && (active_widget == this_widget)
 
-    return widget_value
-end
-
-function do_widget!(widget_type::TextBox, hot_widget, active_widget, null_widget, this_widget, widget_value, i_mouse, j_mouse, ended_down, num_transitions, characters, i_min, j_min, i_max, j_max)
+function do_widget(widget_type::TextBox, hot_widget, active_widget, null_widget, this_widget, i_mouse, j_mouse, ended_down, num_transitions, characters, i_min, j_min, i_max, j_max)
     mouse_over_widget = (i_min <= i_mouse <= i_max) && (j_min <= j_mouse <= j_max)
     mouse_went_down = went_down(ended_down, num_transitions)
     mouse_went_up = went_up(ended_down, num_transitions)
@@ -149,7 +135,7 @@ function do_widget!(widget_type::TextBox, hot_widget, active_widget, null_widget
 
     active_widget = try_set_active_widget(hot_widget, active_widget, null_widget, this_widget, mouse_over_widget && mouse_went_up)
 
-    widget_value = get_widget_value!(widget_type, hot_widget, active_widget, this_widget, widget_value, characters)
+    widget_value = get_widget_value(widget_type, hot_widget, active_widget, this_widget)
 
     active_widget = try_reset_active_widget(hot_widget, active_widget, null_widget, this_widget, !mouse_over_widget && mouse_went_up)
 
@@ -158,7 +144,7 @@ function do_widget!(widget_type::TextBox, hot_widget, active_widget, null_widget
     return hot_widget, active_widget, null_widget, widget_value
 end
 
-do_widget!!(widget_type::TextBox, args...; kwargs...) = do_widget!(widget_type, args...; kwargs...)
+do_widget!!(widget_type::TextBox, args...; kwargs...) = do_widget(widget_type, args...; kwargs...)
 
 #####
 ##### CheckBox

--- a/src/widget_core.jl
+++ b/src/widget_core.jl
@@ -92,7 +92,7 @@ end
 ##### Button
 #####
 
-function do_widget(widget_type::Union{Button, Text, Image}, hot_widget, active_widget, null_widget, this_widget, i_mouse, j_mouse, ended_down, num_transitions, i_min, j_min, i_max, j_max)
+function get_widget_interaction(widget_type::Union{Button, Text, Image}, hot_widget, active_widget, null_widget, this_widget, i_mouse, j_mouse, ended_down, num_transitions, i_min, j_min, i_max, j_max)
     mouse_over_widget = (i_min <= i_mouse <= i_max) && (j_min <= j_mouse <= j_max)
     mouse_went_down = went_down(ended_down, num_transitions)
     mouse_went_up = went_up(ended_down, num_transitions)
@@ -118,7 +118,7 @@ end
 ##### TextBox
 #####
 
-function do_widget(widget_type::TextBox, hot_widget, active_widget, null_widget, this_widget, i_mouse, j_mouse, ended_down, num_transitions, characters, i_min, j_min, i_max, j_max)
+function get_widget_interaction(widget_type::TextBox, hot_widget, active_widget, null_widget, this_widget, i_mouse, j_mouse, ended_down, num_transitions, characters, i_min, j_min, i_max, j_max)
     mouse_over_widget = (i_min <= i_mouse <= i_max) && (j_min <= j_mouse <= j_max)
     mouse_went_down = went_down(ended_down, num_transitions)
     mouse_went_up = went_up(ended_down, num_transitions)
@@ -140,8 +140,8 @@ end
 ##### CheckBox
 #####
 
-function do_widget(widget_type::Union{CheckBox, RadioButton, DropDown}, hot_widget, active_widget, null_widget, this_widget, widget_value, i_mouse, j_mouse, ended_down, num_transitions, i_min, j_min, i_max, j_max)
-    hot_widget, active_widget, null_widget, button_value = do_widget(BUTTON, hot_widget, active_widget, null_widget, this_widget, i_mouse, j_mouse, ended_down, num_transitions, i_min, j_min, i_max, j_max)
+function get_widget_interaction(widget_type::Union{CheckBox, RadioButton, DropDown}, hot_widget, active_widget, null_widget, this_widget, widget_value, i_mouse, j_mouse, ended_down, num_transitions, i_min, j_min, i_max, j_max)
+    hot_widget, active_widget, null_widget, button_value = get_widget_interaction(BUTTON, hot_widget, active_widget, null_widget, this_widget, i_mouse, j_mouse, ended_down, num_transitions, i_min, j_min, i_max, j_max)
 
     if button_value
         widget_value = !widget_value
@@ -158,7 +158,7 @@ get_scroll_value(i_bar_wrt_slider, length_bar, length_slider, length_view, lengt
 
 get_bar_length(min_length_bar, length_slider, length_view, length_full) = max(min_length_bar, (length_slider * length_view) ÷ length_full)
 
-function do_widget(widget_type::Slider, hot_widget, active_widget, null_widget, this_widget, i_bar_wrt_slider, j_bar_wrt_slider, height_bar, width_bar, i_bar_wrt_mouse, j_bar_wrt_mouse, height_slider, width_slider, i_mouse, j_mouse, ended_down, num_transitions, i_min_slider, j_min_slider, i_max_slider, j_max_slider)
+function get_widget_interaction(widget_type::Slider, hot_widget, active_widget, null_widget, this_widget, i_bar_wrt_slider, j_bar_wrt_slider, height_bar, width_bar, i_bar_wrt_mouse, j_bar_wrt_mouse, height_slider, width_slider, i_mouse, j_mouse, ended_down, num_transitions, i_min_slider, j_min_slider, i_max_slider, j_max_slider)
     height_slider = i_max_slider - i_min_slider + one(i_min_slider)
     width_slider = j_max_slider - j_min_slider + one(j_min_slider)
 

--- a/src/widget_core.jl
+++ b/src/widget_core.jl
@@ -146,7 +146,7 @@ get_widget_interaction(widget_type::Text, args...; kwargs...) = get_widget_inter
 ##### CheckBox
 #####
 
-function get_widget_interaction(widget_type::Union{CheckBox, RadioButton, DropDown}, hot_widget, active_widget, null_widget, this_widget, widget_value, i_mouse, j_mouse, ended_down, num_transitions, i_min, j_min, i_max, j_max)
+function get_widget_interaction(widget_type::CheckBox, hot_widget, active_widget, null_widget, this_widget, widget_value, i_mouse, j_mouse, ended_down, num_transitions, i_min, j_min, i_max, j_max)
     hot_widget, active_widget, null_widget, button_value = get_widget_interaction(BUTTON, hot_widget, active_widget, null_widget, this_widget, i_mouse, j_mouse, ended_down, num_transitions, i_min, j_min, i_max, j_max)
 
     if button_value
@@ -155,6 +155,18 @@ function get_widget_interaction(widget_type::Union{CheckBox, RadioButton, DropDo
 
     return hot_widget, active_widget, null_widget, widget_value
 end
+
+#####
+##### RadioButton
+#####
+
+get_widget_interaction(widget_type::RadioButton, args...; kwargs...) = get_widget_interaction(CHECK_BOX, args...; kwargs...)
+
+#####
+##### DropDown
+#####
+
+get_widget_interaction(widget_type::DropDown, args...; kwargs...) = get_widget_interaction(CHECK_BOX, args...; kwargs...)
 
 #####
 ##### Slider

--- a/src/widget_core.jl
+++ b/src/widget_core.jl
@@ -92,7 +92,7 @@ end
 ##### Button
 #####
 
-function get_widget_interaction(widget_type::Union{Button, Text, Image}, hot_widget, active_widget, null_widget, this_widget, i_mouse, j_mouse, ended_down, num_transitions, i_min, j_min, i_max, j_max)
+function get_widget_interaction(widget_type::Button, hot_widget, active_widget, null_widget, this_widget, i_mouse, j_mouse, ended_down, num_transitions, i_min, j_min, i_max, j_max)
     mouse_over_widget = (i_min <= i_mouse <= i_max) && (j_min <= j_mouse <= j_max)
     mouse_went_down = went_down(ended_down, num_transitions)
     mouse_went_up = went_up(ended_down, num_transitions)
@@ -135,6 +135,12 @@ function get_widget_interaction(widget_type::TextBox, hot_widget, active_widget,
 
     return hot_widget, active_widget, null_widget, widget_value
 end
+
+#####
+##### Text
+#####
+
+get_widget_interaction(widget_type::Text, args...; kwargs...) = get_widget_interaction(BUTTON, args...; kwargs...)
 
 #####
 ##### CheckBox
@@ -197,3 +203,9 @@ function get_widget_interaction(widget_type::Slider, hot_widget, active_widget, 
 
     return hot_widget, active_widget, null_widget, (i_bar_wrt_slider, j_bar_wrt_slider, height_bar, width_bar, i_bar_wrt_mouse, j_bar_wrt_mouse, height_slider, width_slider)
 end
+
+#####
+##### Image
+#####
+
+get_widget_interaction(widget_type::Image, args...; kwargs...) = get_widget_interaction(BUTTON, args...; kwargs...)

--- a/src/widget_core.jl
+++ b/src/widget_core.jl
@@ -118,8 +118,6 @@ function do_widget(widget_type::Union{Button, Text, Image}, hot_widget, active_w
     return hot_widget, active_widget, null_widget, widget_value
 end
 
-do_widget!!(widget_type::Union{Button, Text, Image}, args...; kwargs...) = do_widget(widget_type, args...; kwargs...)
-
 #####
 ##### TextBox
 #####
@@ -144,8 +142,6 @@ function do_widget(widget_type::TextBox, hot_widget, active_widget, null_widget,
     return hot_widget, active_widget, null_widget, widget_value
 end
 
-do_widget!!(widget_type::TextBox, args...; kwargs...) = do_widget(widget_type, args...; kwargs...)
-
 #####
 ##### CheckBox
 #####
@@ -159,8 +155,6 @@ function do_widget(widget_type::Union{CheckBox, RadioButton, DropDown}, hot_widg
 
     return hot_widget, active_widget, null_widget, widget_value
 end
-
-do_widget!!(widget_type::Union{CheckBox, RadioButton, DropDown}, args...; kwargs...) = do_widget(widget_type, args...; kwargs...)
 
 #####
 ##### Slider
@@ -217,5 +211,3 @@ function do_widget(widget_type::Slider, hot_widget, active_widget, null_widget, 
 
     return hot_widget, active_widget, null_widget, (i_bar_wrt_slider, j_bar_wrt_slider, height_bar, width_bar, i_bar_wrt_mouse, j_bar_wrt_mouse, height_slider, width_slider)
 end
-
-do_widget!!(widget_type::Slider, args...; kwargs...) = do_widget(widget_type, args...; kwargs...)

--- a/src/widget_core.jl
+++ b/src/widget_core.jl
@@ -92,14 +92,6 @@ end
 ##### Button
 #####
 
-function get_widget_value(::Union{Button, Text, Image}, hot_widget, active_widget, this_widget, condition)
-    if (hot_widget == this_widget) && (active_widget == this_widget) && condition
-        return true
-    else
-        return false
-    end
-end
-
 function do_widget(widget_type::Union{Button, Text, Image}, hot_widget, active_widget, null_widget, this_widget, i_mouse, j_mouse, ended_down, num_transitions, i_min, j_min, i_max, j_max)
     mouse_over_widget = (i_min <= i_mouse <= i_max) && (j_min <= j_mouse <= j_max)
     mouse_went_down = went_down(ended_down, num_transitions)
@@ -109,7 +101,11 @@ function do_widget(widget_type::Union{Button, Text, Image}, hot_widget, active_w
 
     active_widget = try_set_active_widget(hot_widget, active_widget, null_widget, this_widget, mouse_over_widget && mouse_went_down)
 
-    widget_value = get_widget_value(widget_type, hot_widget, active_widget, this_widget, mouse_over_widget && mouse_went_up)
+    if (hot_widget == this_widget) && (active_widget == this_widget) && mouse_over_widget && mouse_went_up
+        widget_value = true
+    else
+        widget_value = false
+    end
 
     active_widget = try_reset_active_widget(hot_widget, active_widget, null_widget, this_widget, mouse_went_up)
 
@@ -122,8 +118,6 @@ end
 ##### TextBox
 #####
 
-get_widget_value(::TextBox, hot_widget, active_widget, this_widget) = (hot_widget == this_widget) && (active_widget == this_widget)
-
 function do_widget(widget_type::TextBox, hot_widget, active_widget, null_widget, this_widget, i_mouse, j_mouse, ended_down, num_transitions, characters, i_min, j_min, i_max, j_max)
     mouse_over_widget = (i_min <= i_mouse <= i_max) && (j_min <= j_mouse <= j_max)
     mouse_went_down = went_down(ended_down, num_transitions)
@@ -133,7 +127,7 @@ function do_widget(widget_type::TextBox, hot_widget, active_widget, null_widget,
 
     active_widget = try_set_active_widget(hot_widget, active_widget, null_widget, this_widget, mouse_over_widget && mouse_went_up)
 
-    widget_value = get_widget_value(widget_type, hot_widget, active_widget, this_widget)
+    widget_value = (hot_widget == this_widget) && (active_widget == this_widget)
 
     active_widget = try_reset_active_widget(hot_widget, active_widget, null_widget, this_widget, !mouse_over_widget && mouse_went_up)
 
@@ -159,20 +153,6 @@ end
 #####
 ##### Slider
 #####
-
-function get_widget_value(widget_type::Slider, hot_widget, active_widget, this_widget, i_bar_wrt_slider, j_bar_wrt_slider, height_bar, width_bar, i_bar_wrt_mouse, j_bar_wrt_mouse, i_mouse, j_mouse, i_min_slider, j_min_slider, i_max_slider, j_max_slider)
-    if (hot_widget == this_widget) && (active_widget == this_widget)
-        i_bar_wrt_slider = i_mouse + i_bar_wrt_mouse - i_min_slider
-        j_bar_wrt_slider = j_mouse + j_bar_wrt_mouse - j_min_slider
-
-        i_bar_wrt_slider = clamp(i_bar_wrt_slider, zero(i_bar_wrt_slider), i_max_slider - i_min_slider + one(i_min_slider) - height_bar)
-        j_bar_wrt_slider = clamp(j_bar_wrt_slider, zero(j_bar_wrt_slider), j_max_slider - j_min_slider + one(j_min_slider) - width_bar)
-
-        return i_bar_wrt_slider, j_bar_wrt_slider
-    else
-        return i_bar_wrt_slider, j_bar_wrt_slider
-    end
-end
 
 get_scroll_value(i_bar_wrt_slider, length_bar, length_slider, length_view, length_full) = i_bar_wrt_slider * (length_full - length_view) ÷ (length_slider - length_bar)
 
@@ -203,7 +183,13 @@ function do_widget(widget_type::Slider, hot_widget, active_widget, null_widget, 
 
     active_widget = try_set_active_widget(hot_widget, active_widget, null_widget, this_widget, mouse_over_bar && mouse_went_down)
 
-    i_bar_wrt_slider, j_bar_wrt_slider = get_widget_value(widget_type, hot_widget, active_widget, this_widget, i_bar_wrt_slider, j_bar_wrt_slider, height_bar, width_bar, i_bar_wrt_mouse, j_bar_wrt_mouse, i_mouse, j_mouse, i_min_slider, j_min_slider, i_max_slider, j_max_slider)
+    if (hot_widget == this_widget) && (active_widget == this_widget)
+        i_bar_wrt_slider = i_mouse + i_bar_wrt_mouse - i_min_slider
+        j_bar_wrt_slider = j_mouse + j_bar_wrt_mouse - j_min_slider
+
+        i_bar_wrt_slider = clamp(i_bar_wrt_slider, zero(i_bar_wrt_slider), i_max_slider - i_min_slider + one(i_min_slider) - height_bar)
+        j_bar_wrt_slider = clamp(j_bar_wrt_slider, zero(j_bar_wrt_slider), j_max_slider - j_min_slider + one(j_min_slider) - width_bar)
+    end
 
     active_widget = try_reset_active_widget(hot_widget, active_widget, null_widget, this_widget, mouse_went_up)
 

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -12,58 +12,6 @@ end
 #####
 
 function do_widget!(
-        widget_type::Union{CheckBox, RadioButton, DropDown},
-        user_interaction_state::AbstractUserInteractionState,
-        this_widget,
-        widget_value,
-        cursor_position,
-        input_button,
-        layout,
-        alignment,
-        padding,
-        widget_height,
-        widget_width,
-        image,
-        content_alignment,
-        content_padding,
-        text,
-        font,
-        background_color,
-        border_color,
-        text_color,
-        indicator_color,
-    )
-
-    widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
-    layout.reference_bounding_box = widget_bounding_box
-
-    hot_widget, active_widget, null_widget, widget_value = get_widget_interaction(
-        widget_type,
-        user_interaction_state.hot_widget,
-        user_interaction_state.active_widget,
-        user_interaction_state.null_widget,
-        this_widget,
-        widget_value,
-        cursor_position.i,
-        cursor_position.j,
-        input_button.ended_down,
-        input_button.num_transitions,
-        SD.get_i_min(widget_bounding_box),
-        SD.get_j_min(widget_bounding_box),
-        SD.get_i_max(widget_bounding_box),
-        SD.get_j_max(widget_bounding_box),
-    )
-
-    user_interaction_state.hot_widget = hot_widget
-    user_interaction_state.active_widget = active_widget
-    user_interaction_state.null_widget = null_widget
-
-    draw_widget!(widget_type, image, widget_bounding_box, user_interaction_state, this_widget, widget_value, content_alignment, content_padding, text, font, background_color, border_color, text_color, indicator_color)
-
-    return widget_value
-end
-
-function do_widget!(
         widget_type::TextBox,
         user_interaction_state::AbstractUserInteractionState,
         this_widget,
@@ -290,25 +238,42 @@ function do_widget!(
         font,
     )
 
-    do_widget!(
+    layout = ui_context.layout
+    user_interaction_state = ui_context.user_interaction_state
+    cursor_position = ui_context.user_input_state.cursor.position
+    input_button = first(ui_context.user_input_state.mouse_buttons)
+    image = ui_context.image
+    content_alignment = get_content_alignment(widget_type)
+    content_padding = get_content_padding(widget_type)
+    background_color, border_color, text_color, indicator_color = get_colors(widget_type)
+
+    widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
+    layout.reference_bounding_box = widget_bounding_box
+
+    hot_widget, active_widget, null_widget, widget_value = get_widget_interaction(
         widget_type,
-        ui_context.user_interaction_state,
+        user_interaction_state.hot_widget,
+        user_interaction_state.active_widget,
+        user_interaction_state.null_widget,
         this_widget,
         widget_value,
-        ui_context.user_input_state.cursor.position,
-        first(ui_context.user_input_state.mouse_buttons), # assuming first one is left mouse button (it will work for GLFW at least)
-        ui_context.layout,
-        alignment,
-        padding,
-        widget_height,
-        widget_width,
-        ui_context.image,
-        get_content_alignment(widget_type),
-        get_content_padding(widget_type),
-        text,
-        font,
-        get_colors(widget_type)...,
+        cursor_position.i,
+        cursor_position.j,
+        input_button.ended_down,
+        input_button.num_transitions,
+        SD.get_i_min(widget_bounding_box),
+        SD.get_j_min(widget_bounding_box),
+        SD.get_i_max(widget_bounding_box),
+        SD.get_j_max(widget_bounding_box),
     )
+
+    user_interaction_state.hot_widget = hot_widget
+    user_interaction_state.active_widget = active_widget
+    user_interaction_state.null_widget = null_widget
+
+    draw_widget!(widget_type, image, widget_bounding_box, user_interaction_state, this_widget, widget_value, content_alignment, content_padding, text, font, background_color, border_color, text_color, indicator_color)
+
+    return widget_value
 end
 
 function do_widget!(

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -7,8 +7,6 @@ struct UIContext{T, I1, I2, A} <: AbstractUIContext
     image::A
 end
 
-get_content_padding(::AbstractWidgetType) = 0
-
 function do_widget!(
         widget_type::Button,
         ui_context::AbstractUIContext,
@@ -20,6 +18,7 @@ function do_widget!(
         widget_height = SD.get_height(font),
         widget_width = get_num_printable_characters(text) * SD.get_width(font),
         content_alignment = CENTER,
+        content_padding = 0,
     )
 
     layout = ui_context.layout
@@ -27,7 +26,6 @@ function do_widget!(
     cursor_position = ui_context.user_input_state.cursor.position
     input_button = first(ui_context.user_input_state.mouse_buttons)
     image = ui_context.image
-    content_padding = get_content_padding(widget_type)
     background_color, border_color, text_color = get_colors(widget_type)
 
     widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
@@ -69,6 +67,7 @@ function do_widget!(
         widget_height = SD.get_height(font),
         widget_width = get_num_printable_characters(text) * SD.get_width(font),
         content_alignment = UP1_LEFT1,
+        content_padding = 0,
     )
 
     layout = ui_context.layout
@@ -76,7 +75,6 @@ function do_widget!(
     cursor_position = ui_context.user_input_state.cursor.position
     input_button = first(ui_context.user_input_state.mouse_buttons)
     image = ui_context.image
-    content_padding = get_content_padding(widget_type)
     background_color, border_color, text_color = get_colors(widget_type)
 
     widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
@@ -119,6 +117,7 @@ function do_widget!(
         widget_height = SD.get_height(font),
         widget_width = (get_num_printable_characters(text) + 2) * SD.get_width(font),
         content_alignment = UP1_LEFT1,
+        content_padding = 0,
     )
 
     layout = ui_context.layout
@@ -126,7 +125,6 @@ function do_widget!(
     cursor_position = ui_context.user_input_state.cursor.position
     input_button = first(ui_context.user_input_state.mouse_buttons)
     image = ui_context.image
-    content_padding = get_content_padding(widget_type)
     background_color, border_color, text_color, indicator_color = get_colors(widget_type)
 
     widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
@@ -170,6 +168,7 @@ function do_widget!(
         widget_height = SD.get_height(font),
         widget_width = (get_num_printable_characters(text) + 2) * SD.get_width(font),
         content_alignment = UP1_LEFT1,
+        content_padding = 0,
     )
 
     layout = ui_context.layout
@@ -177,7 +176,6 @@ function do_widget!(
     cursor_position = ui_context.user_input_state.cursor.position
     input_button = first(ui_context.user_input_state.mouse_buttons)
     image = ui_context.image
-    content_padding = get_content_padding(widget_type)
     background_color, border_color, text_color, indicator_color = get_colors(widget_type)
 
     widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
@@ -221,6 +219,7 @@ function do_widget!(
         widget_height = SD.get_height(font),
         widget_width = (get_num_printable_characters(text) + 2) * SD.get_width(font),
         content_alignment = UP1_LEFT1,
+        content_padding = 0,
     )
 
     layout = ui_context.layout
@@ -228,7 +227,6 @@ function do_widget!(
     cursor_position = ui_context.user_input_state.cursor.position
     input_button = first(ui_context.user_input_state.mouse_buttons)
     image = ui_context.image
-    content_padding = get_content_padding(widget_type)
     background_color, border_color, text_color, indicator_color = get_colors(widget_type)
 
     widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
@@ -271,6 +269,7 @@ function do_widget!(
         widget_height = SD.get_height(font),
         widget_width = max(1, get_num_printable_characters(text)) * SD.get_width(font),
         content_alignment = UP1_LEFT1,
+        content_padding = 0,
     )
 
     layout = ui_context.layout
@@ -279,7 +278,6 @@ function do_widget!(
     input_button = first(ui_context.user_input_state.mouse_buttons)
     characters = ui_context.user_input_state.characters
     image = ui_context.image
-    content_padding = get_content_padding(widget_type)
     background_color, border_color, text_color = get_colors(widget_type)
 
     widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
@@ -340,7 +338,6 @@ function do_widget!(
     cursor_position = ui_context.user_input_state.cursor.position
     input_button = first(ui_context.user_input_state.mouse_buttons)
     image = ui_context.image
-    content_padding = get_content_padding(widget_type)
     background_color, border_color, indicator_color = get_colors(widget_type)
 
     widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
@@ -383,6 +380,7 @@ function do_widget!(
         widget_height = SD.get_height(image_content),
         widget_width = SD.get_width(image_content),
         content_alignment = UP1_LEFT1,
+        content_padding = 0,
     )
 
     layout = ui_context.layout
@@ -390,7 +388,6 @@ function do_widget!(
     cursor_position = ui_context.user_input_state.cursor.position
     input_button = first(ui_context.user_input_state.mouse_buttons)
     image = ui_context.image
-    content_padding = get_content_padding(widget_type)
     border_color = get_colors(widget_type)[1]
 
     widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -7,9 +7,6 @@ struct UIContext{T, I1, I2, A} <: AbstractUIContext
     image::A
 end
 
-get_content_alignment(::AbstractWidgetType) = UP1_LEFT1
-get_content_alignment(::Button) = CENTER
-
 get_content_padding(::AbstractWidgetType) = 0
 
 function do_widget!(
@@ -22,6 +19,7 @@ function do_widget!(
         padding = SD.get_height(font) ÷ 4,
         widget_height = SD.get_height(font),
         widget_width = get_num_printable_characters(text) * SD.get_width(font),
+        content_alignment = CENTER,
     )
 
     layout = ui_context.layout
@@ -29,7 +27,6 @@ function do_widget!(
     cursor_position = ui_context.user_input_state.cursor.position
     input_button = first(ui_context.user_input_state.mouse_buttons)
     image = ui_context.image
-    content_alignment = get_content_alignment(widget_type)
     content_padding = get_content_padding(widget_type)
     background_color, border_color, text_color = get_colors(widget_type)
 
@@ -71,6 +68,7 @@ function do_widget!(
         padding = SD.get_height(font) ÷ 4,
         widget_height = SD.get_height(font),
         widget_width = get_num_printable_characters(text) * SD.get_width(font),
+        content_alignment = UP1_LEFT1,
     )
 
     layout = ui_context.layout
@@ -78,7 +76,6 @@ function do_widget!(
     cursor_position = ui_context.user_input_state.cursor.position
     input_button = first(ui_context.user_input_state.mouse_buttons)
     image = ui_context.image
-    content_alignment = get_content_alignment(widget_type)
     content_padding = get_content_padding(widget_type)
     background_color, border_color, text_color = get_colors(widget_type)
 
@@ -121,6 +118,7 @@ function do_widget!(
         padding = SD.get_height(font) ÷ 4,
         widget_height = SD.get_height(font),
         widget_width = (get_num_printable_characters(text) + 2) * SD.get_width(font),
+        content_alignment = UP1_LEFT1,
     )
 
     layout = ui_context.layout
@@ -128,7 +126,6 @@ function do_widget!(
     cursor_position = ui_context.user_input_state.cursor.position
     input_button = first(ui_context.user_input_state.mouse_buttons)
     image = ui_context.image
-    content_alignment = get_content_alignment(widget_type)
     content_padding = get_content_padding(widget_type)
     background_color, border_color, text_color, indicator_color = get_colors(widget_type)
 
@@ -172,6 +169,7 @@ function do_widget!(
         padding = SD.get_height(font) ÷ 4,
         widget_height = SD.get_height(font),
         widget_width = (get_num_printable_characters(text) + 2) * SD.get_width(font),
+        content_alignment = UP1_LEFT1,
     )
 
     layout = ui_context.layout
@@ -179,7 +177,6 @@ function do_widget!(
     cursor_position = ui_context.user_input_state.cursor.position
     input_button = first(ui_context.user_input_state.mouse_buttons)
     image = ui_context.image
-    content_alignment = get_content_alignment(widget_type)
     content_padding = get_content_padding(widget_type)
     background_color, border_color, text_color, indicator_color = get_colors(widget_type)
 
@@ -223,6 +220,7 @@ function do_widget!(
         padding = SD.get_height(font) ÷ 4,
         widget_height = SD.get_height(font),
         widget_width = (get_num_printable_characters(text) + 2) * SD.get_width(font),
+        content_alignment = UP1_LEFT1,
     )
 
     layout = ui_context.layout
@@ -230,7 +228,6 @@ function do_widget!(
     cursor_position = ui_context.user_input_state.cursor.position
     input_button = first(ui_context.user_input_state.mouse_buttons)
     image = ui_context.image
-    content_alignment = get_content_alignment(widget_type)
     content_padding = get_content_padding(widget_type)
     background_color, border_color, text_color, indicator_color = get_colors(widget_type)
 
@@ -273,6 +270,7 @@ function do_widget!(
         padding = SD.get_height(font) ÷ 4,
         widget_height = SD.get_height(font),
         widget_width = max(1, get_num_printable_characters(text)) * SD.get_width(font),
+        content_alignment = UP1_LEFT1,
     )
 
     layout = ui_context.layout
@@ -281,7 +279,6 @@ function do_widget!(
     input_button = first(ui_context.user_input_state.mouse_buttons)
     characters = ui_context.user_input_state.characters
     image = ui_context.image
-    content_alignment = get_content_alignment(widget_type)
     content_padding = get_content_padding(widget_type)
     background_color, border_color, text_color = get_colors(widget_type)
 
@@ -343,7 +340,6 @@ function do_widget!(
     cursor_position = ui_context.user_input_state.cursor.position
     input_button = first(ui_context.user_input_state.mouse_buttons)
     image = ui_context.image
-    content_alignment = get_content_alignment(widget_type)
     content_padding = get_content_padding(widget_type)
     background_color, border_color, indicator_color = get_colors(widget_type)
 
@@ -386,6 +382,7 @@ function do_widget!(
         padding = SD.get_height(font) ÷ 4,
         widget_height = SD.get_height(image_content),
         widget_width = SD.get_width(image_content),
+        content_alignment = UP1_LEFT1,
     )
 
     layout = ui_context.layout
@@ -393,7 +390,6 @@ function do_widget!(
     cursor_position = ui_context.user_input_state.cursor.position
     input_button = first(ui_context.user_input_state.mouse_buttons)
     image = ui_context.image
-    content_alignment = get_content_alignment(widget_type)
     content_padding = get_content_padding(widget_type)
     border_color = get_colors(widget_type)[1]
 

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -7,60 +7,6 @@ struct UIContext{T, I1, I2, A} <: AbstractUIContext
     image::A
 end
 
-#####
-##### helper methods that bundle some of the arguments for methods in widget_core.jl and also do widget layouting and drawing
-#####
-
-function do_widget!(
-        widget_type::Image,
-        user_interaction_state::AbstractUserInteractionState,
-        this_widget,
-        cursor_position,
-        input_button,
-        layout,
-        alignment,
-        padding,
-        widget_height,
-        widget_width,
-        image,
-        content_alignment,
-        content_padding,
-        content,
-        border_color,
-    )
-
-    widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
-    layout.reference_bounding_box = widget_bounding_box
-
-    hot_widget, active_widget, null_widget, widget_value = get_widget_interaction(
-        widget_type,
-        user_interaction_state.hot_widget,
-        user_interaction_state.active_widget,
-        user_interaction_state.null_widget,
-        this_widget,
-        cursor_position.i,
-        cursor_position.j,
-        input_button.ended_down,
-        input_button.num_transitions,
-        SD.get_i_min(widget_bounding_box),
-        SD.get_j_min(widget_bounding_box),
-        SD.get_i_max(widget_bounding_box),
-        SD.get_j_max(widget_bounding_box),
-    )
-
-    user_interaction_state.hot_widget = hot_widget
-    user_interaction_state.active_widget = active_widget
-    user_interaction_state.null_widget = null_widget
-
-    draw_widget!(widget_type, image, widget_bounding_box, user_interaction_state, this_widget, content, content_alignment, content_padding, border_color)
-
-    return widget_value
-end
-
-#####
-##### helper methods that take default values for some of the arguments and shorten usage of do_widget!
-#####
-
 get_content_alignment(::AbstractWidgetType) = UP1_LEFT1
 get_content_alignment(::Button) = CENTER
 
@@ -286,24 +232,42 @@ function do_widget!(
         padding,
         widget_height,
         widget_width,
-        image,
+        image_content,
     )
 
-    do_widget!(
+    layout = ui_context.layout
+    user_interaction_state = ui_context.user_interaction_state
+    cursor_position = ui_context.user_input_state.cursor.position
+    input_button = first(ui_context.user_input_state.mouse_buttons)
+    image = ui_context.image
+    content_alignment = get_content_alignment(widget_type)
+    content_padding = get_content_padding(widget_type)
+    border_color = get_colors(widget_type)[1]
+
+    widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
+    layout.reference_bounding_box = widget_bounding_box
+
+    hot_widget, active_widget, null_widget, widget_value = get_widget_interaction(
         widget_type,
-        ui_context.user_interaction_state,
+        user_interaction_state.hot_widget,
+        user_interaction_state.active_widget,
+        user_interaction_state.null_widget,
         this_widget,
-        ui_context.user_input_state.cursor.position,
-        first(ui_context.user_input_state.mouse_buttons), # assuming first one is left mouse button (it will work for GLFW at least)
-        ui_context.layout,
-        alignment,
-        padding,
-        widget_height,
-        widget_width,
-        ui_context.image,
-        get_content_alignment(widget_type),
-        get_content_padding(widget_type),
-        image,
-        get_colors(widget_type)...,
+        cursor_position.i,
+        cursor_position.j,
+        input_button.ended_down,
+        input_button.num_transitions,
+        SD.get_i_min(widget_bounding_box),
+        SD.get_j_min(widget_bounding_box),
+        SD.get_i_max(widget_bounding_box),
+        SD.get_j_max(widget_bounding_box),
     )
+
+    user_interaction_state.hot_widget = hot_widget
+    user_interaction_state.active_widget = active_widget
+    user_interaction_state.null_widget = null_widget
+
+    draw_widget!(widget_type, image, widget_bounding_box, user_interaction_state, this_widget, image_content, content_alignment, content_padding, border_color)
+
+    return widget_value
 end

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -12,55 +12,6 @@ end
 #####
 
 function do_widget!(
-        widget_type::Union{Button, Text},
-        user_interaction_state::AbstractUserInteractionState,
-        this_widget,
-        cursor_position,
-        input_button,
-        layout,
-        alignment,
-        padding,
-        widget_height,
-        widget_width,
-        image,
-        content_alignment,
-        content_padding,
-        text,
-        font,
-        background_color,
-        border_color,
-        text_color,
-    )
-
-    widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
-    layout.reference_bounding_box = widget_bounding_box
-
-    hot_widget, active_widget, null_widget, widget_value = get_widget_interaction(
-        widget_type,
-        user_interaction_state.hot_widget,
-        user_interaction_state.active_widget,
-        user_interaction_state.null_widget,
-        this_widget,
-        cursor_position.i,
-        cursor_position.j,
-        input_button.ended_down,
-        input_button.num_transitions,
-        SD.get_i_min(widget_bounding_box),
-        SD.get_j_min(widget_bounding_box),
-        SD.get_i_max(widget_bounding_box),
-        SD.get_j_max(widget_bounding_box),
-    )
-
-    user_interaction_state.hot_widget = hot_widget
-    user_interaction_state.active_widget = active_widget
-    user_interaction_state.null_widget = null_widget
-
-    draw_widget!(widget_type, image, widget_bounding_box, user_interaction_state, this_widget, text, font, content_alignment, content_padding, background_color, border_color, text_color)
-
-    return widget_value
-end
-
-function do_widget!(
         widget_type::Union{CheckBox, RadioButton, DropDown},
         user_interaction_state::AbstractUserInteractionState,
         this_widget,
@@ -289,24 +240,41 @@ function do_widget!(
         font,
     )
 
-    do_widget!(
+    layout = ui_context.layout
+    user_interaction_state = ui_context.user_interaction_state
+    cursor_position = ui_context.user_input_state.cursor.position
+    input_button = first(ui_context.user_input_state.mouse_buttons)
+    image = ui_context.image
+    content_alignment = get_content_alignment(widget_type)
+    content_padding = get_content_padding(widget_type)
+    background_color, border_color, text_color = get_colors(widget_type)
+
+    widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
+    layout.reference_bounding_box = widget_bounding_box
+
+    hot_widget, active_widget, null_widget, widget_value = get_widget_interaction(
         widget_type,
-        ui_context.user_interaction_state,
+        user_interaction_state.hot_widget,
+        user_interaction_state.active_widget,
+        user_interaction_state.null_widget,
         this_widget,
-        ui_context.user_input_state.cursor.position,
-        first(ui_context.user_input_state.mouse_buttons), # assuming first one is left mouse button (it will work for GLFW at least)
-        ui_context.layout,
-        alignment,
-        padding,
-        widget_height,
-        widget_width,
-        ui_context.image,
-        get_content_alignment(widget_type),
-        get_content_padding(widget_type),
-        text,
-        font,
-        get_colors(widget_type)...,
+        cursor_position.i,
+        cursor_position.j,
+        input_button.ended_down,
+        input_button.num_transitions,
+        SD.get_i_min(widget_bounding_box),
+        SD.get_j_min(widget_bounding_box),
+        SD.get_i_max(widget_bounding_box),
+        SD.get_j_max(widget_bounding_box),
     )
+
+    user_interaction_state.hot_widget = hot_widget
+    user_interaction_state.active_widget = active_widget
+    user_interaction_state.null_widget = null_widget
+
+    draw_widget!(widget_type, image, widget_bounding_box, user_interaction_state, this_widget, text, font, content_alignment, content_padding, background_color, border_color, text_color)
+
+    return widget_value
 end
 
 function do_widget!(

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -35,7 +35,7 @@ function do_widget!(
     widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
     layout.reference_bounding_box = widget_bounding_box
 
-    hot_widget, active_widget, null_widget, widget_value = do_widget(
+    hot_widget, active_widget, null_widget, widget_value = get_widget_interaction(
         widget_type,
         user_interaction_state.hot_widget,
         user_interaction_state.active_widget,
@@ -86,7 +86,7 @@ function do_widget!(
     widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
     layout.reference_bounding_box = widget_bounding_box
 
-    hot_widget, active_widget, null_widget, widget_value = do_widget(
+    hot_widget, active_widget, null_widget, widget_value = get_widget_interaction(
         widget_type,
         user_interaction_state.hot_widget,
         user_interaction_state.active_widget,
@@ -137,7 +137,7 @@ function do_widget!(
     widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
     layout.reference_bounding_box = widget_bounding_box
 
-    hot_widget, active_widget, null_widget, widget_value = do_widget(
+    hot_widget, active_widget, null_widget, widget_value = get_widget_interaction(
         widget_type,
         user_interaction_state.hot_widget,
         user_interaction_state.active_widget,
@@ -196,7 +196,7 @@ function do_widget!(
     widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
     layout.reference_bounding_box = widget_bounding_box
 
-    hot_widget, active_widget, null_widget, widget_value = do_widget(
+    hot_widget, active_widget, null_widget, widget_value = get_widget_interaction(
         widget_type,
         user_interaction_state.hot_widget,
         user_interaction_state.active_widget,
@@ -243,7 +243,7 @@ function do_widget!(
     widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
     layout.reference_bounding_box = widget_bounding_box
 
-    hot_widget, active_widget, null_widget, widget_value = do_widget(
+    hot_widget, active_widget, null_widget, widget_value = get_widget_interaction(
         widget_type,
         user_interaction_state.hot_widget,
         user_interaction_state.active_widget,

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -330,11 +330,12 @@ function do_widget!(
         widget_type::Slider,
         ui_context::AbstractUIContext,
         this_widget,
-        widget_value,
-        alignment,
-        padding,
-        widget_height,
-        widget_width,
+        widget_value;
+        font = SD.TERMINUS_BOLD_24_12,
+        alignment = DOWN2_LEFT1,
+        padding = SD.get_height(font) ÷ 4,
+        widget_height = SD.get_height(font),
+        widget_width = 8 * SD.get_width(font),
     )
 
     layout = ui_context.layout

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -161,9 +161,107 @@ function do_widget!(
     return widget_value
 end
 
-do_widget!(widget_type::RadioButton, args...; kwargs...) = do_widget!(CHECK_BOX, args...; kwargs...)
+function do_widget!(
+        widget_type::RadioButton,
+        ui_context::AbstractUIContext,
+        this_widget,
+        widget_value,
+        text;
+        font = SD.TERMINUS_BOLD_24_12,
+        alignment = DOWN2_LEFT1,
+        padding = SD.get_height(font) ÷ 4,
+        widget_height = SD.get_height(font),
+        widget_width = (get_num_printable_characters(text) + 2) * SD.get_width(font),
+    )
 
-do_widget!(widget_type::DropDown, args...; kwargs...) = do_widget!(CHECK_BOX, args...; kwargs...)
+    layout = ui_context.layout
+    user_interaction_state = ui_context.user_interaction_state
+    cursor_position = ui_context.user_input_state.cursor.position
+    input_button = first(ui_context.user_input_state.mouse_buttons)
+    image = ui_context.image
+    content_alignment = get_content_alignment(widget_type)
+    content_padding = get_content_padding(widget_type)
+    background_color, border_color, text_color, indicator_color = get_colors(widget_type)
+
+    widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
+    layout.reference_bounding_box = widget_bounding_box
+
+    hot_widget, active_widget, null_widget, widget_value = get_widget_interaction(
+        widget_type,
+        user_interaction_state.hot_widget,
+        user_interaction_state.active_widget,
+        user_interaction_state.null_widget,
+        this_widget,
+        widget_value,
+        cursor_position.i,
+        cursor_position.j,
+        input_button.ended_down,
+        input_button.num_transitions,
+        SD.get_i_min(widget_bounding_box),
+        SD.get_j_min(widget_bounding_box),
+        SD.get_i_max(widget_bounding_box),
+        SD.get_j_max(widget_bounding_box),
+    )
+
+    user_interaction_state.hot_widget = hot_widget
+    user_interaction_state.active_widget = active_widget
+    user_interaction_state.null_widget = null_widget
+
+    draw_widget!(widget_type, image, widget_bounding_box, user_interaction_state, this_widget, widget_value, content_alignment, content_padding, text, font, background_color, border_color, text_color, indicator_color)
+
+    return widget_value
+end
+
+function do_widget!(
+        widget_type::DropDown,
+        ui_context::AbstractUIContext,
+        this_widget,
+        widget_value,
+        text;
+        font = SD.TERMINUS_BOLD_24_12,
+        alignment = DOWN2_LEFT1,
+        padding = SD.get_height(font) ÷ 4,
+        widget_height = SD.get_height(font),
+        widget_width = (get_num_printable_characters(text) + 2) * SD.get_width(font),
+    )
+
+    layout = ui_context.layout
+    user_interaction_state = ui_context.user_interaction_state
+    cursor_position = ui_context.user_input_state.cursor.position
+    input_button = first(ui_context.user_input_state.mouse_buttons)
+    image = ui_context.image
+    content_alignment = get_content_alignment(widget_type)
+    content_padding = get_content_padding(widget_type)
+    background_color, border_color, text_color, indicator_color = get_colors(widget_type)
+
+    widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
+    layout.reference_bounding_box = widget_bounding_box
+
+    hot_widget, active_widget, null_widget, widget_value = get_widget_interaction(
+        widget_type,
+        user_interaction_state.hot_widget,
+        user_interaction_state.active_widget,
+        user_interaction_state.null_widget,
+        this_widget,
+        widget_value,
+        cursor_position.i,
+        cursor_position.j,
+        input_button.ended_down,
+        input_button.num_transitions,
+        SD.get_i_min(widget_bounding_box),
+        SD.get_j_min(widget_bounding_box),
+        SD.get_i_max(widget_bounding_box),
+        SD.get_j_max(widget_bounding_box),
+    )
+
+    user_interaction_state.hot_widget = hot_widget
+    user_interaction_state.active_widget = active_widget
+    user_interaction_state.null_widget = null_widget
+
+    draw_widget!(widget_type, image, widget_bounding_box, user_interaction_state, this_widget, widget_value, content_alignment, content_padding, text, font, background_color, border_color, text_color, indicator_color)
+
+    return widget_value
+end
 
 function do_widget!(
         widget_type::TextBox,

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -267,12 +267,12 @@ function do_widget!(
         widget_type::TextBox,
         ui_context::AbstractUIContext,
         this_widget,
-        alignment,
-        padding,
-        widget_height,
-        widget_width,
-        text,
-        font,
+        text;
+        font = SD.TERMINUS_BOLD_24_12,
+        alignment = DOWN2_LEFT1,
+        padding = SD.get_height(font) ÷ 4,
+        widget_height = SD.get_height(font),
+        widget_width = max(1, get_num_printable_characters(text)) * SD.get_width(font),
     )
 
     layout = ui_context.layout

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -380,11 +380,12 @@ function do_widget!(
         widget_type::Image,
         ui_context::AbstractUIContext,
         this_widget,
-        alignment,
-        padding,
-        widget_height,
-        widget_width,
-        image_content,
+        image_content;
+        font = SD.TERMINUS_BOLD_24_12,
+        alignment = DOWN2_LEFT1,
+        padding = SD.get_height(font) ÷ 4,
+        widget_height = SD.get_height(image_content),
+        widget_width = SD.get_width(image_content),
     )
 
     layout = ui_context.layout

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -16,12 +16,12 @@ function do_widget!(
         widget_type::Button,
         ui_context::AbstractUIContext,
         this_widget,
-        alignment,
-        padding,
-        widget_height,
-        widget_width,
-        text,
-        font,
+        text;
+        font = SD.TERMINUS_BOLD_24_12,
+        alignment = DOWN2_LEFT1,
+        padding = SD.get_height(font) ÷ 4,
+        widget_height = SD.get_height(font),
+        widget_width = length(text) * SD.get_width(font),
     )
 
     layout = ui_context.layout

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -21,7 +21,7 @@ function do_widget!(
         alignment = DOWN2_LEFT1,
         padding = SD.get_height(font) ÷ 4,
         widget_height = SD.get_height(font),
-        widget_width = length(text) * SD.get_width(font),
+        widget_width = get_num_printable_characters(text) * SD.get_width(font),
     )
 
     layout = ui_context.layout

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -68,12 +68,12 @@ function do_widget!(
         ui_context::AbstractUIContext,
         this_widget,
         widget_value,
-        alignment,
-        padding,
-        widget_height,
-        widget_width,
-        text,
-        font,
+        text;
+        font = SD.TERMINUS_BOLD_24_12,
+        alignment = DOWN2_LEFT1,
+        padding = SD.get_height(font) ÷ 4,
+        widget_height = SD.get_height(font),
+        widget_width = (get_num_printable_characters(text) + 2) * SD.get_width(font),
     )
 
     layout = ui_context.layout

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -12,53 +12,6 @@ end
 #####
 
 function do_widget!(
-        widget_type::Slider,
-        user_interaction_state::AbstractUserInteractionState,
-        this_widget,
-        widget_value,
-        cursor_position,
-        input_button,
-        layout,
-        alignment,
-        padding,
-        widget_height,
-        widget_width,
-        image,
-        background_color,
-        border_color,
-        indicator_color,
-    )
-
-    widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
-    layout.reference_bounding_box = widget_bounding_box
-
-    hot_widget, active_widget, null_widget, widget_value = get_widget_interaction(
-        widget_type,
-        user_interaction_state.hot_widget,
-        user_interaction_state.active_widget,
-        user_interaction_state.null_widget,
-        this_widget,
-        widget_value...,
-        cursor_position.i,
-        cursor_position.j,
-        input_button.ended_down,
-        input_button.num_transitions,
-        SD.get_i_min(widget_bounding_box),
-        SD.get_j_min(widget_bounding_box),
-        SD.get_i_max(widget_bounding_box),
-        SD.get_j_max(widget_bounding_box),
-    )
-
-    user_interaction_state.hot_widget = hot_widget
-    user_interaction_state.active_widget = active_widget
-    user_interaction_state.null_widget = null_widget
-
-    draw_widget!(widget_type, image, widget_bounding_box, user_interaction_state, this_widget, widget_value, background_color, border_color, indicator_color)
-
-    return widget_value
-end
-
-function do_widget!(
         widget_type::Image,
         user_interaction_state::AbstractUserInteractionState,
         this_widget,
@@ -287,21 +240,42 @@ function do_widget!(
         widget_width,
     )
 
-    do_widget!(
+    layout = ui_context.layout
+    user_interaction_state = ui_context.user_interaction_state
+    cursor_position = ui_context.user_input_state.cursor.position
+    input_button = first(ui_context.user_input_state.mouse_buttons)
+    image = ui_context.image
+    content_alignment = get_content_alignment(widget_type)
+    content_padding = get_content_padding(widget_type)
+    background_color, border_color, indicator_color = get_colors(widget_type)
+
+    widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
+    layout.reference_bounding_box = widget_bounding_box
+
+    hot_widget, active_widget, null_widget, widget_value = get_widget_interaction(
         widget_type,
-        ui_context.user_interaction_state,
+        user_interaction_state.hot_widget,
+        user_interaction_state.active_widget,
+        user_interaction_state.null_widget,
         this_widget,
-        widget_value,
-        ui_context.user_input_state.cursor.position,
-        first(ui_context.user_input_state.mouse_buttons), # assuming first one is left mouse button (it will work for GLFW at least)
-        ui_context.layout,
-        alignment,
-        padding,
-        widget_height,
-        widget_width,
-        ui_context.image,
-        get_colors(widget_type)...,
+        widget_value...,
+        cursor_position.i,
+        cursor_position.j,
+        input_button.ended_down,
+        input_button.num_transitions,
+        SD.get_i_min(widget_bounding_box),
+        SD.get_j_min(widget_bounding_box),
+        SD.get_i_max(widget_bounding_box),
+        SD.get_j_max(widget_bounding_box),
     )
+
+    user_interaction_state.hot_widget = hot_widget
+    user_interaction_state.active_widget = active_widget
+    user_interaction_state.null_widget = null_widget
+
+    draw_widget!(widget_type, image, widget_bounding_box, user_interaction_state, this_widget, widget_value, background_color, border_color, indicator_color)
+
+    return widget_value
 end
 
 function do_widget!(

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -13,7 +13,7 @@ get_content_alignment(::Button) = CENTER
 get_content_padding(::AbstractWidgetType) = 0
 
 function do_widget!(
-        widget_type::Union{Button, Text},
+        widget_type::Button,
         ui_context::AbstractUIContext,
         this_widget,
         alignment,
@@ -61,8 +61,10 @@ function do_widget!(
     return widget_value
 end
 
+do_widget!(widget_type::Text, args...; kwargs...) = do_widget!(BUTTON, args...; kwargs...)
+
 function do_widget!(
-        widget_type::Union{CheckBox, RadioButton, DropDown},
+        widget_type::CheckBox,
         ui_context::AbstractUIContext,
         this_widget,
         widget_value,
@@ -111,6 +113,10 @@ function do_widget!(
 
     return widget_value
 end
+
+do_widget!(widget_type::RadioButton, args...; kwargs...) = do_widget!(CHECK_BOX, args...; kwargs...)
+
+do_widget!(widget_type::DropDown, args...; kwargs...) = do_widget!(CHECK_BOX, args...; kwargs...)
 
 function do_widget!(
         widget_type::TextBox,

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -61,7 +61,54 @@ function do_widget!(
     return widget_value
 end
 
-do_widget!(widget_type::Text, args...; kwargs...) = do_widget!(BUTTON, args...; kwargs...)
+function do_widget!(
+        widget_type::Text,
+        ui_context::AbstractUIContext,
+        this_widget,
+        text;
+        font = SD.TERMINUS_BOLD_24_12,
+        alignment = DOWN2_LEFT1,
+        padding = SD.get_height(font) ÷ 4,
+        widget_height = SD.get_height(font),
+        widget_width = get_num_printable_characters(text) * SD.get_width(font),
+    )
+
+    layout = ui_context.layout
+    user_interaction_state = ui_context.user_interaction_state
+    cursor_position = ui_context.user_input_state.cursor.position
+    input_button = first(ui_context.user_input_state.mouse_buttons)
+    image = ui_context.image
+    content_alignment = get_content_alignment(widget_type)
+    content_padding = get_content_padding(widget_type)
+    background_color, border_color, text_color = get_colors(widget_type)
+
+    widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
+    layout.reference_bounding_box = widget_bounding_box
+
+    hot_widget, active_widget, null_widget, widget_value = get_widget_interaction(
+        widget_type,
+        user_interaction_state.hot_widget,
+        user_interaction_state.active_widget,
+        user_interaction_state.null_widget,
+        this_widget,
+        cursor_position.i,
+        cursor_position.j,
+        input_button.ended_down,
+        input_button.num_transitions,
+        SD.get_i_min(widget_bounding_box),
+        SD.get_j_min(widget_bounding_box),
+        SD.get_i_max(widget_bounding_box),
+        SD.get_j_max(widget_bounding_box),
+    )
+
+    user_interaction_state.hot_widget = hot_widget
+    user_interaction_state.active_widget = active_widget
+    user_interaction_state.null_widget = null_widget
+
+    draw_widget!(widget_type, image, widget_bounding_box, user_interaction_state, this_widget, text, font, content_alignment, content_padding, background_color, border_color, text_color)
+
+    return widget_value
+end
 
 function do_widget!(
         widget_type::CheckBox,

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -35,7 +35,7 @@ function do_widget!(
     widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
     layout.reference_bounding_box = widget_bounding_box
 
-    hot_widget, active_widget, null_widget, widget_value = do_widget!!(
+    hot_widget, active_widget, null_widget, widget_value = do_widget(
         widget_type,
         user_interaction_state.hot_widget,
         user_interaction_state.active_widget,
@@ -86,7 +86,7 @@ function do_widget!(
     widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
     layout.reference_bounding_box = widget_bounding_box
 
-    hot_widget, active_widget, null_widget, widget_value = do_widget!!(
+    hot_widget, active_widget, null_widget, widget_value = do_widget(
         widget_type,
         user_interaction_state.hot_widget,
         user_interaction_state.active_widget,
@@ -137,7 +137,7 @@ function do_widget!(
     widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
     layout.reference_bounding_box = widget_bounding_box
 
-    hot_widget, active_widget, null_widget, widget_value = do_widget!!(
+    hot_widget, active_widget, null_widget, widget_value = do_widget(
         widget_type,
         user_interaction_state.hot_widget,
         user_interaction_state.active_widget,
@@ -196,7 +196,7 @@ function do_widget!(
     widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
     layout.reference_bounding_box = widget_bounding_box
 
-    hot_widget, active_widget, null_widget, widget_value = do_widget!!(
+    hot_widget, active_widget, null_widget, widget_value = do_widget(
         widget_type,
         user_interaction_state.hot_widget,
         user_interaction_state.active_widget,
@@ -243,7 +243,7 @@ function do_widget!(
     widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
     layout.reference_bounding_box = widget_bounding_box
 
-    hot_widget, active_widget, null_widget, widget_value = do_widget!!(
+    hot_widget, active_widget, null_widget, widget_value = do_widget(
         widget_type,
         user_interaction_state.hot_widget,
         user_interaction_state.active_widget,

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -116,7 +116,6 @@ function do_widget!(
         widget_type::TextBox,
         user_interaction_state::AbstractUserInteractionState,
         this_widget,
-        widget_value,
         cursor_position,
         input_button,
         characters,
@@ -128,6 +127,7 @@ function do_widget!(
         image,
         content_alignment,
         content_padding,
+        text,
         font,
         background_color,
         border_color,
@@ -143,7 +143,6 @@ function do_widget!(
         user_interaction_state.active_widget,
         user_interaction_state.null_widget,
         this_widget,
-        widget_value,
         cursor_position.i,
         cursor_position.j,
         input_button.ended_down,
@@ -159,7 +158,19 @@ function do_widget!(
     user_interaction_state.active_widget = active_widget
     user_interaction_state.null_widget = null_widget
 
-    draw_widget!(widget_type, image, widget_bounding_box, user_interaction_state, this_widget, widget_value, content_alignment, content_padding, font, background_color, border_color, text_color)
+    if widget_value
+        for character in characters
+            if isprint(character)
+                push!(text, character)
+            elseif character == '\b'
+                if get_num_printable_characters(text) > 0
+                    pop!(text)
+                end
+            end
+        end
+    end
+
+    draw_widget!(widget_type, image, widget_bounding_box, user_interaction_state, this_widget, content_alignment, content_padding, text, font, background_color, border_color, text_color)
 
     return widget_value
 end
@@ -336,11 +347,11 @@ function do_widget!(
         widget_type::TextBox,
         ui_context::AbstractUIContext,
         this_widget,
-        widget_value,
         alignment,
         padding,
         widget_height,
         widget_width,
+        text,
         font,
     )
 
@@ -348,7 +359,6 @@ function do_widget!(
         widget_type,
         ui_context.user_interaction_state,
         this_widget,
-        widget_value,
         ui_context.user_input_state.cursor.position,
         first(ui_context.user_input_state.mouse_buttons), # assuming first one is left mouse button (it will work for GLFW at least)
         ui_context.user_input_state.characters,
@@ -360,6 +370,7 @@ function do_widget!(
         ui_context.image,
         get_content_alignment(widget_type),
         get_content_padding(widget_type),
+        text,
         font,
         get_colors(widget_type)...,
     )

--- a/src/widget_utils.jl
+++ b/src/widget_utils.jl
@@ -12,69 +12,6 @@ end
 #####
 
 function do_widget!(
-        widget_type::TextBox,
-        user_interaction_state::AbstractUserInteractionState,
-        this_widget,
-        cursor_position,
-        input_button,
-        characters,
-        layout,
-        alignment,
-        padding,
-        widget_height,
-        widget_width,
-        image,
-        content_alignment,
-        content_padding,
-        text,
-        font,
-        background_color,
-        border_color,
-        text_color,
-    )
-
-    widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
-    layout.reference_bounding_box = widget_bounding_box
-
-    hot_widget, active_widget, null_widget, widget_value = get_widget_interaction(
-        widget_type,
-        user_interaction_state.hot_widget,
-        user_interaction_state.active_widget,
-        user_interaction_state.null_widget,
-        this_widget,
-        cursor_position.i,
-        cursor_position.j,
-        input_button.ended_down,
-        input_button.num_transitions,
-        characters,
-        SD.get_i_min(widget_bounding_box),
-        SD.get_j_min(widget_bounding_box),
-        SD.get_i_max(widget_bounding_box),
-        SD.get_j_max(widget_bounding_box),
-    )
-
-    user_interaction_state.hot_widget = hot_widget
-    user_interaction_state.active_widget = active_widget
-    user_interaction_state.null_widget = null_widget
-
-    if widget_value
-        for character in characters
-            if isprint(character)
-                push!(text, character)
-            elseif character == '\b'
-                if get_num_printable_characters(text) > 0
-                    pop!(text)
-                end
-            end
-        end
-    end
-
-    draw_widget!(widget_type, image, widget_bounding_box, user_interaction_state, this_widget, content_alignment, content_padding, text, font, background_color, border_color, text_color)
-
-    return widget_value
-end
-
-function do_widget!(
         widget_type::Slider,
         user_interaction_state::AbstractUserInteractionState,
         this_widget,
@@ -288,25 +225,55 @@ function do_widget!(
         font,
     )
 
-    do_widget!(
+    layout = ui_context.layout
+    user_interaction_state = ui_context.user_interaction_state
+    cursor_position = ui_context.user_input_state.cursor.position
+    input_button = first(ui_context.user_input_state.mouse_buttons)
+    characters = ui_context.user_input_state.characters
+    image = ui_context.image
+    content_alignment = get_content_alignment(widget_type)
+    content_padding = get_content_padding(widget_type)
+    background_color, border_color, text_color = get_colors(widget_type)
+
+    widget_bounding_box = get_alignment_bounding_box(layout.reference_bounding_box, alignment, padding, widget_height, widget_width)
+    layout.reference_bounding_box = widget_bounding_box
+
+    hot_widget, active_widget, null_widget, widget_value = get_widget_interaction(
         widget_type,
-        ui_context.user_interaction_state,
+        user_interaction_state.hot_widget,
+        user_interaction_state.active_widget,
+        user_interaction_state.null_widget,
         this_widget,
-        ui_context.user_input_state.cursor.position,
-        first(ui_context.user_input_state.mouse_buttons), # assuming first one is left mouse button (it will work for GLFW at least)
-        ui_context.user_input_state.characters,
-        ui_context.layout,
-        alignment,
-        padding,
-        widget_height,
-        widget_width,
-        ui_context.image,
-        get_content_alignment(widget_type),
-        get_content_padding(widget_type),
-        text,
-        font,
-        get_colors(widget_type)...,
+        cursor_position.i,
+        cursor_position.j,
+        input_button.ended_down,
+        input_button.num_transitions,
+        characters,
+        SD.get_i_min(widget_bounding_box),
+        SD.get_j_min(widget_bounding_box),
+        SD.get_i_max(widget_bounding_box),
+        SD.get_j_max(widget_bounding_box),
     )
+
+    user_interaction_state.hot_widget = hot_widget
+    user_interaction_state.active_widget = active_widget
+    user_interaction_state.null_widget = null_widget
+
+    if widget_value
+        for character in characters
+            if isprint(character)
+                push!(text, character)
+            elseif character == '\b'
+                if get_num_printable_characters(text) > 0
+                    pop!(text)
+                end
+            end
+        end
+    end
+
+    draw_widget!(widget_type, image, widget_bounding_box, user_interaction_state, this_widget, content_alignment, content_padding, text, font, background_color, border_color, text_color)
+
+    return widget_value
 end
 
 function do_widget!(


### PR DESCRIPTION
1. For `TextBox`, at the lowest level, just return whether the text needs to be updated or not. Do not pass text and update it over there. This also makes the function pure.
2. Remove `do_widget!!` function since all lowermost level methods are pure. Rename those from `do_widget` to `get_widget_interaction`.
3. Remove intermediate `do_widget!` methods in `widget_utils.jl` for now.
4. Separate out `do_widget!` and `get_widget_interaction` methods for all widgets. Use method forwarding where necessary, instead of `Union`s.
5. Add a bunch of keyword arguments to `do_widget!` to simplify outermost usage. Remove `get_content_alignment` and `get_content_padding` functions.